### PR TITLE
Feature/remove env vars

### DIFF
--- a/OracleSOASuite/dockerfiles/12.2.1.3/Dockerfile
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/Dockerfile
@@ -35,7 +35,9 @@ COPY container-scripts/* /u01/oracle/dockertools/
 RUN  yum install -y hostname install net-tools procps-ng curl telnet vim &&    \
      rm -rf /var/cache/yum &&      \
      cd /u01 && chmod 755 *.jar && \
-     chmod a+xr /u01/oracle/dockertools/*.*
+     chmod a+xr /u01/oracle/dockertools/*.* && \
+     ln -s /usr/java/jdk1.8.0_211 /usr/java/jdk-8
+
 #
 USER oracle
 COPY install/* /u01/

--- a/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
@@ -201,12 +201,8 @@ fi
 
 # Force variable values
 export USER=weblogic
-export PASS=soaspikeWelcome123
-export DB_SCHEMA_PASS=soaspikeWelcome123
 export DOMAIN_ROOT=${DOMAIN_ROOT:-/u01/oracle/user_projects/domains}
 export DOMAIN_HOME=${DOMAIN_ROOT}/${DOMAIN_NAME}
-export ADMIN_HOST=ccms-soa-admin.dev.legalservices.gov.uk
-export MANAGED_HOST=ccms-soa-managed.dev.legalservices.gov.uk
 
 # Print our all of the variable values to stdout
 echo oh = ${ORACLE_HOME}
@@ -225,6 +221,7 @@ echo ap = ${ADMINISTRATION_PORT}
 echo mn = ${MANAGED_NAME}
 echo msp = ${MANAGEDSERVER_PORT}
 echo pm = ${PRODUCTION_MODE}
+echo ah = ${ADMIN_HOST}
 
 echo "Configuring Domain"
 if [ "$CONFIGURE_DOMAIN" = "true" ]

--- a/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
@@ -273,11 +273,6 @@ echo "password="$ADMIN_PASSWORD >> $DOMAIN_HOME/servers/${MANAGED_SERVER}/securi
 echo ". $DOMAIN_HOME/bin/setDomainEnv.sh" >> /u01/oracle/.bashrc
 echo "export PATH=$PATH:/u01/oracle/common/bin:$DOMAIN_HOME/bin" >> /u01/oracle/.bashrc
 
-# Create java symlinks
-ls -l /usr/java/jdk1.8.0_211 /usr/java/latest
-ls -l /usr/java/jdk1.8.0_211 /usr/java/default
-ls -l /usr/java/jdk1.8.0_211 /usr/java/jdk-8
-
 # Now we start the Admin server in this container...
 /u01/oracle/dockertools/startAS.sh
 

--- a/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/startMS.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/startMS.sh
@@ -64,11 +64,6 @@ export thehost=`hostname -I`
 echo "INFO: Updating the listen address - ${thehost} ${MANAGED_HOST}"
 /u01/oracle/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning /u01/oracle/dockertools/updListenAddress.py $vol_name $thehost ${MANAGED_SERVER} ${MANAGED_HOST} > ${LOGDIR}/mslisten.log 2>&1
 
-# Create java symlinks
-ls -l /usr/java/jdk1.8.0_211 /usr/java/latest
-ls -l /usr/java/jdk1.8.0_211 /usr/java/default
-ls -l /usr/java/jdk1.8.0_211 /usr/java/jdk-8
-
 # Start SOA server
 echo "INFO: Starting the managed server ${MANAGED_SERVER}"
 $DOMAIN_HOME/bin/startManagedWebLogic.sh ${MANAGED_SERVER} "http://"${ADMIN_HOST}:${ADMIN_PORT} > ${LOGFILE} 2>&1 &


### PR DESCRIPTION
Java home is being set as jdk-8 but java is in a different location, this fixes this.  Initially tried to add the symlink in the scripts, but you need to be root (also typos in those anyway 🤦‍♂ ) But adding to the docker file is fine.

Removing the environment vars is ok, admin server starts up with this.  I've not tested this with a complete clean new build (ie db restore) yet.

Managed server also starting fine.  So at this point in time we have a working admin and managed server.