### PR TITLE
Increasing wait before first time ms start

### DIFF
--- a/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/startMS.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/startMS.sh
@@ -73,7 +73,7 @@ then
     sleep 10
   done
   echo "INFO: Script present, wait to ensure everything is created"
-  sleep 300
+  sleep 500
 fi
 
 # Start SOA server


### PR DESCRIPTION
The managed server still isn't starting cleanly on the first run,
increasing the wait time to ensure everything required is created.  It
starts clean if you kill the task and it starts again.